### PR TITLE
Develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
+
+## 1.2.1 - 2018-10-03
+
+### Added
+- AMQP Qos options support added to Amqp client configuration (The default number of preload messages is 100)
+- Limited number of tasks running simultaneously. Now, no more than 50 (previously there was no limit)
+
+### Deprecated
+- Nothing
+
+### Fixed
+- Fixed a memory leak in the transport level
+- Optimized RAM usage
+
+### Removed
+- Nothing
+
+### Security
+- Nothing

--- a/composer.lock
+++ b/composer.lock
@@ -2114,16 +2114,16 @@
         },
         {
             "name": "symfony/cache",
-            "version": "v4.1.4",
+            "version": "v4.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache.git",
-                "reference": "b8440ff4635c6631aca21a09ab72e0b7e3a6cb7a"
+                "reference": "05ce0ddc8bc1ffe592105398fc2c725cb3080a38"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache/zipball/b8440ff4635c6631aca21a09ab72e0b7e3a6cb7a",
-                "reference": "b8440ff4635c6631aca21a09ab72e0b7e3a6cb7a",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/05ce0ddc8bc1ffe592105398fc2c725cb3080a38",
+                "reference": "05ce0ddc8bc1ffe592105398fc2c725cb3080a38",
                 "shasum": ""
             },
             "require": {
@@ -2179,7 +2179,7 @@
                 "caching",
                 "psr6"
             ],
-            "time": "2018-08-27 09:36:56"
+            "time": "2018-09-30 03:38:13"
         },
         {
             "name": "symfony/config",
@@ -2246,16 +2246,16 @@
         },
         {
             "name": "symfony/debug",
-            "version": "v4.1.4",
+            "version": "v4.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "47ead688f1f2877f3f14219670f52e4722ee7052"
+                "reference": "b4a0b67dee59e2cae4449a8f8eabc508d622fd33"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/47ead688f1f2877f3f14219670f52e4722ee7052",
-                "reference": "47ead688f1f2877f3f14219670f52e4722ee7052",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/b4a0b67dee59e2cae4449a8f8eabc508d622fd33",
+                "reference": "b4a0b67dee59e2cae4449a8f8eabc508d622fd33",
                 "shasum": ""
             },
             "require": {
@@ -2298,7 +2298,7 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2018-08-03 11:13:38"
+            "time": "2018-09-22 19:04:12"
         },
         {
             "name": "symfony/dependency-injection",
@@ -2373,7 +2373,7 @@
         },
         {
             "name": "symfony/dotenv",
-            "version": "v4.1.4",
+            "version": "v4.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dotenv.git",
@@ -2430,16 +2430,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v4.1.4",
+            "version": "v4.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "c0f5f62db218fa72195b8b8700e4b9b9cf52eb5e"
+                "reference": "a10ae719b02c47ecba5c684ca2b505f3a49bf397"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/c0f5f62db218fa72195b8b8700e4b9b9cf52eb5e",
-                "reference": "c0f5f62db218fa72195b8b8700e4b9b9cf52eb5e",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/a10ae719b02c47ecba5c684ca2b505f3a49bf397",
+                "reference": "a10ae719b02c47ecba5c684ca2b505f3a49bf397",
                 "shasum": ""
             },
             "require": {
@@ -2476,11 +2476,11 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2018-08-18 16:52:46"
+            "time": "2018-09-30 03:38:13"
         },
         {
             "name": "symfony/inflector",
-            "version": "v4.1.4",
+            "version": "v4.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/inflector.git",
@@ -2655,16 +2655,16 @@
         },
         {
             "name": "symfony/property-access",
-            "version": "v4.1.4",
+            "version": "v4.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/property-access.git",
-                "reference": "ae8561ba08af38e12dc5e21582ddb4baf66719ca"
+                "reference": "02abada997e3ec63bbf41ef859900b31d074f171"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/property-access/zipball/ae8561ba08af38e12dc5e21582ddb4baf66719ca",
-                "reference": "ae8561ba08af38e12dc5e21582ddb4baf66719ca",
+                "url": "https://api.github.com/repos/symfony/property-access/zipball/02abada997e3ec63bbf41ef859900b31d074f171",
+                "reference": "02abada997e3ec63bbf41ef859900b31d074f171",
                 "shasum": ""
             },
             "require": {
@@ -2718,11 +2718,11 @@
                 "property path",
                 "reflection"
             ],
-            "time": "2018-08-24 10:22:26"
+            "time": "2018-09-08 13:24:10"
         },
         {
             "name": "symfony/property-info",
-            "version": "v4.1.4",
+            "version": "v4.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/property-info.git",
@@ -2798,16 +2798,16 @@
         },
         {
             "name": "symfony/serializer",
-            "version": "v4.1.4",
+            "version": "v4.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/serializer.git",
-                "reference": "2f134b6cad1cefa0613a4339b08e480124914c85"
+                "reference": "23c0673e02bf5cb88e2297ef0be31a713900de1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/serializer/zipball/2f134b6cad1cefa0613a4339b08e480124914c85",
-                "reference": "2f134b6cad1cefa0613a4339b08e480124914c85",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/23c0673e02bf5cb88e2297ef0be31a713900de1f",
+                "reference": "23c0673e02bf5cb88e2297ef0be31a713900de1f",
                 "shasum": ""
             },
             "require": {
@@ -2874,20 +2874,20 @@
             ],
             "description": "Symfony Serializer Component",
             "homepage": "https://symfony.com",
-            "time": "2018-07-26 09:10:45"
+            "time": "2018-09-21 12:49:42"
         },
         {
             "name": "symfony/translation",
-            "version": "v4.1.4",
+            "version": "v4.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "fa2182669f7983b7aa5f1a770d053f79f0ef144f"
+                "reference": "6e49130ddf150b7bfe9e34edb2f3f698aa1aa43b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/fa2182669f7983b7aa5f1a770d053f79f0ef144f",
-                "reference": "fa2182669f7983b7aa5f1a770d053f79f0ef144f",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/6e49130ddf150b7bfe9e34edb2f3f698aa1aa43b",
+                "reference": "6e49130ddf150b7bfe9e34edb2f3f698aa1aa43b",
                 "shasum": ""
             },
             "require": {
@@ -2943,7 +2943,7 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2018-08-07 12:45:11"
+            "time": "2018-09-21 12:49:42"
         },
         {
             "name": "symfony/validator",

--- a/composer.lock
+++ b/composer.lock
@@ -571,12 +571,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/postgres.git",
-                "reference": "4e2ca3760817ace288e2dc72c56741fb27467c3b"
+                "reference": "964ec8759b68326c240411d88fc5ff0808b966e6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/postgres/zipball/4e2ca3760817ace288e2dc72c56741fb27467c3b",
-                "reference": "4e2ca3760817ace288e2dc72c56741fb27467c3b",
+                "url": "https://api.github.com/repos/amphp/postgres/zipball/964ec8759b68326c240411d88fc5ff0808b966e6",
+                "reference": "964ec8759b68326c240411d88fc5ff0808b966e6",
                 "shasum": ""
             },
             "require": {
@@ -621,7 +621,7 @@
                 "postgre",
                 "postgresql"
             ],
-            "time": "2018-09-26 17:47:08"
+            "time": "2018-10-02 03:58:35"
         },
         {
             "name": "amphp/process",
@@ -680,16 +680,16 @@
         },
         {
             "name": "amphp/socket",
-            "version": "v0.10.9",
+            "version": "v0.10.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/socket.git",
-                "reference": "6e9686b62b87c2cad235139a44be5121fe34edbb"
+                "reference": "efbe8fb64cf0ddcb4034076ebf1e64920c1259e2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/socket/zipball/6e9686b62b87c2cad235139a44be5121fe34edbb",
-                "reference": "6e9686b62b87c2cad235139a44be5121fe34edbb",
+                "url": "https://api.github.com/repos/amphp/socket/zipball/efbe8fb64cf0ddcb4034076ebf1e64920c1259e2",
+                "reference": "efbe8fb64cf0ddcb4034076ebf1e64920c1259e2",
                 "shasum": ""
             },
             "require": {
@@ -743,7 +743,7 @@
                 "tcp",
                 "tls"
             ],
-            "time": "2018-05-01 21:14:10"
+            "time": "2018-10-03 09:32:18"
         },
         {
             "name": "amphp/sql",

--- a/src/Application/ServiceBusKernel.php
+++ b/src/Application/ServiceBusKernel.php
@@ -29,6 +29,7 @@ use Desperado\ServiceBus\Transport\OutboundEnvelope;
 use Desperado\ServiceBus\Transport\Publisher;
 use Desperado\ServiceBus\Transport\Queue;
 use Desperado\ServiceBus\Transport\Transport;
+use Desperado\ServiceBus\Transport\TransportContext;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
@@ -218,24 +219,24 @@ final class ServiceBusKernel
         $logger     = $this->kernelContainer->get(LoggerInterface::class);
         $messageBus = $this->messageBus;
 
-        return static function(IncomingEnvelope $envelope) use ($messagePublisher, $messageBus, $logger): \Generator
+        return static function(IncomingEnvelope $envelope, TransportContext $context) use ($messagePublisher, $messageBus, $logger): \Generator
         {
-            self::beforeDispatch($envelope, $logger);
+            self::beforeDispatch($envelope, $context, $logger);
 
             try
             {
                 yield $messageBus->dispatch(
-                    new KernelContext($envelope, $messagePublisher, $logger)
+                    new KernelContext($envelope, $context, $messagePublisher, $logger)
                 );
             }
             catch(NoMessageHandlersFound $exception)
             {
-                $logger->debug($exception->getMessage(), ['operationId' => $envelope->operationId()]);
+                $logger->debug($exception->getMessage(), ['operationId' => $context->id()]);
             }
             catch(\Throwable $throwable)
             {
                 $logger->critical($throwable->getMessage(), [
-                    'operationId' => $envelope->operationId(),
+                    'operationId' => $context->id(),
                     'file'        => \sprintf('%s:%d', $throwable->getFile(), $throwable->getLine())
                 ]);
                 /** @todo: retry message? */
@@ -254,7 +255,7 @@ final class ServiceBusKernel
         $messageRoutes = $this->kernelContainer->get(OutboundMessageRoutes::class);
         $logger        = $this->kernelContainer->get(LoggerInterface::class);
 
-        return static function(Message $message, array $headers, IncomingEnvelope $incomingEnvelope) use (
+        return static function(Message $message, array $headers, IncomingEnvelope $incomingEnvelope, TransportContext $transportContext) use (
             $publisher, $messageRoutes, $logger
         ): \Generator
         {
@@ -265,7 +266,7 @@ final class ServiceBusKernel
             {
                 $outboundEnvelope = self::createOutboundEnvelope(
                     $publisher,
-                    $incomingEnvelope->operationId(),
+                    $transportContext->id(),
                     $message,
                     \array_merge([
                         'x-message-class'         => $messageClass,
@@ -319,15 +320,16 @@ final class ServiceBusKernel
 
     /**
      * @param IncomingEnvelope $envelope
+     * @param TransportContext $context
      * @param LoggerInterface  $logger
      *
      * @return void
      */
-    private static function beforeDispatch(IncomingEnvelope $envelope, LoggerInterface $logger): void
+    private static function beforeDispatch(IncomingEnvelope $envelope, TransportContext $context, LoggerInterface $logger): void
     {
         $logger->debug('Dispatching the message "{messageClass}"', [
                 'messageClass' => \get_class($envelope->denormalized()),
-                'operationId'  => $envelope->operationId(),
+                'operationId'  => $context->id(),
             ]
         );
 
@@ -337,7 +339,7 @@ final class ServiceBusKernel
                     'rawMessagePayload'        => $envelope->requestBody(),
                     'normalizedMessagePayload' => $envelope->normalized(),
                     'headers'                  => $envelope->headers(),
-                    'operationId'              => $envelope->operationId()
+                    'operationId'              => $context->id()
                 ]
             );
         }

--- a/src/Application/ServiceBusKernel.php
+++ b/src/Application/ServiceBusKernel.php
@@ -219,7 +219,7 @@ final class ServiceBusKernel
         $logger     = $this->kernelContainer->get(LoggerInterface::class);
         $messageBus = $this->messageBus;
 
-        return static function(IncomingEnvelope $envelope, TransportContext $context) use ($messagePublisher, $messageBus, $logger): \Generator
+        return static function(IncomingEnvelope $envelope, TransportContext $context) use ($messagePublisher, $messageBus, $logger)
         {
             self::beforeDispatch($envelope, $context, $logger);
 
@@ -280,6 +280,8 @@ final class ServiceBusKernel
                 try
                 {
                     yield $publisher->send($destination, $outboundEnvelope);
+
+                    unset($outboundEnvelope);
                 }
                 catch(\Throwable $throwable)
                 {

--- a/src/Application/ServiceBusKernel.php
+++ b/src/Application/ServiceBusKernel.php
@@ -85,6 +85,7 @@ final class ServiceBusKernel
 
     /**
      * Enable watch for event loop blocking
+     * DO NOT USE IN PRODUCTION environment
      *
      * @return self
      */

--- a/src/DependencyInjection/service_bus.yaml
+++ b/src/DependencyInjection/service_bus.yaml
@@ -38,6 +38,7 @@ services:
     class: Desperado\ServiceBus\Transport\Amqp\Bunny\AmqpBunny
     arguments:
       $amqpConfiguration: '@Desperado\ServiceBus\Transport\Amqp\AmqpConnectionConfiguration'
+      $amqpQoSConfiguration: null
       $messageEncoder: null
       $messageDecoder: null
       $logger: '@Psr\Log\LoggerInterface'
@@ -135,9 +136,9 @@ services:
     class: Symfony\Component\DependencyInjection\ServiceLocator
     tags: ['container.service_locator']
     arguments:
-    - Desperado\ServiceBus\Transport\Transport: '@Desperado\ServiceBus\Transport\Transport'
-      Desperado\ServiceBus\MessageBus\MessageBusBuilder: '@Desperado\ServiceBus\MessageBus\MessageBusBuilder'
-      Desperado\ServiceBus\OutboundMessage\OutboundMessageRoutes: '@Desperado\ServiceBus\OutboundMessage\OutboundMessageRoutes'
-      Desperado\ServiceBus\Application\TransportConfigurator: '@Desperado\ServiceBus\Application\TransportConfigurator'
-      Psr\Log\LoggerInterface: '@Psr\Log\LoggerInterface'
-      Desperado\ServiceBus\Infrastructure\LoopMonitor\LoopBlockDetector: '@Desperado\ServiceBus\Infrastructure\LoopMonitor\LoopBlockDetector'
+      - Desperado\ServiceBus\Transport\Transport: '@Desperado\ServiceBus\Transport\Transport'
+        Desperado\ServiceBus\MessageBus\MessageBusBuilder: '@Desperado\ServiceBus\MessageBus\MessageBusBuilder'
+        Desperado\ServiceBus\OutboundMessage\OutboundMessageRoutes: '@Desperado\ServiceBus\OutboundMessage\OutboundMessageRoutes'
+        Desperado\ServiceBus\Application\TransportConfigurator: '@Desperado\ServiceBus\Application\TransportConfigurator'
+        Psr\Log\LoggerInterface: '@Psr\Log\LoggerInterface'
+        Desperado\ServiceBus\Infrastructure\LoopMonitor\LoopBlockDetector: '@Desperado\ServiceBus\Infrastructure\LoopMonitor\LoopBlockDetector'

--- a/src/EventSourcingSnapshots/Snapshotter.php
+++ b/src/EventSourcingSnapshots/Snapshotter.php
@@ -15,7 +15,6 @@ namespace Desperado\ServiceBus\EventSourcingSnapshots;
 
 use function Amp\call;
 use Amp\Promise;
-use Amp\Success;
 use Desperado\ServiceBus\EventSourcing\Aggregate;
 use Desperado\ServiceBus\EventSourcing\AggregateId;
 use Desperado\ServiceBus\EventSourcing\AggregateSnapshot;
@@ -99,16 +98,16 @@ final class Snapshotter
                             \unserialize($storedSnapshot->payload(), ['allowed_classes' => true]),
                             $storedSnapshot->version()
                         );
-                    }
 
-                    return yield new Success($snapshot);
+                        unset($storedSnapshot);
+                    }
                 }
                 catch(\Throwable $throwable)
                 {
                     $logger->error($throwable->getMessage(), ['e' => $throwable]);
                 }
 
-                return yield new Success($snapshot);
+                return $snapshot;
             },
             $id
         );
@@ -151,8 +150,6 @@ final class Snapshotter
                 {
                     $logger->error($throwable->getMessage(), ['e' => $throwable]);
                 }
-
-                return yield new Success();
             },
             $snapshot
         );

--- a/src/IndexProvider.php
+++ b/src/IndexProvider.php
@@ -15,7 +15,6 @@ namespace Desperado\ServiceBus;
 
 use function Amp\call;
 use Amp\Promise;
-use Amp\Success;
 use Desperado\ServiceBus\Index\IndexKey;
 use Desperado\ServiceBus\Index\Storage\IndexesStorage;
 use Desperado\ServiceBus\Index\IndexValue;
@@ -64,7 +63,7 @@ final class IndexProvider
 
                 if(null !== $value && true === \is_scalar($value))
                 {
-                    return yield new Success(IndexValue::create($value));
+                    return IndexValue::create($value);
                 }
             },
             $indexKey
@@ -96,12 +95,7 @@ final class IndexProvider
                     $indexKey->valueKey()
                 );
 
-                if(null !== $value && true === \is_scalar($value))
-                {
-                    return yield new Success(true);
-                }
-
-                return yield new Success(false);
+                return null !== $value && true === \is_scalar($value);
             },
             $indexKey
         );
@@ -135,11 +129,11 @@ final class IndexProvider
                         $value->value()
                     );
 
-                    return yield new Success(true);
+                    return true;
                 }
                 catch(UniqueConstraintViolationCheckFailed $exception)
                 {
-                    return yield new Success(false);
+                    return false;
                 }
             },
             $indexKey, $value

--- a/src/Infrastructure/HttpClient/Artax/ArtaxHttpClient.php
+++ b/src/Infrastructure/HttpClient/Artax/ArtaxHttpClient.php
@@ -24,7 +24,6 @@ use Amp\Failure;
 use function Amp\File\open;
 use Amp\File\StatCache;
 use Amp\Promise;
-use Amp\Success;
 use function Desperado\ServiceBus\Common\uuid;
 use Desperado\ServiceBus\Infrastructure\HttpClient\Data\HttpRequest;
 use Desperado\ServiceBus\Infrastructure\HttpClient\HttpClient;
@@ -109,7 +108,7 @@ final class ArtaxHttpClient implements HttpClient
 
                 StatCache::clear($tmpDirectoryPath);
 
-                return yield new Success($destinationFilePath);
+                return $destinationFilePath;
             },
             $filePath, $destinationDirectory, $fileName
         );
@@ -183,7 +182,7 @@ final class ArtaxHttpClient implements HttpClient
 
                     self::logResponse($logger, $response, $requestId);
 
-                    return yield new Success($response);
+                    return $response;
                 }
                 catch(\Throwable $throwable)
                 {
@@ -210,15 +209,13 @@ final class ArtaxHttpClient implements HttpClient
                 /** @psalm-suppress InvalidCast */
                 $responseBody = (string) yield $response->getBody();
 
-                $result = new Psr7Response(
+                return new Psr7Response(
                     $response->getStatus(),
                     $response->getHeaders(),
                     $responseBody,
                     $response->getProtocolVersion(),
                     $response->getReason()
                 );
-
-                return yield new Success($result);
             },
             $response
         );

--- a/src/Infrastructure/LoopMonitor/LoopBlockDetector.php
+++ b/src/Infrastructure/LoopMonitor/LoopBlockDetector.php
@@ -18,6 +18,8 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
 /**
+ * DO NOT USE IN PRODUCTION environment!
+ *
  * @codeCoverageIgnore
  */
 final class LoopBlockDetector

--- a/src/MessageBus/MessageBus.php
+++ b/src/MessageBus/MessageBus.php
@@ -66,6 +66,8 @@ final class MessageBus
 
                     yield $task($message, $context);
                 }
+
+                unset($message, $messageClass);
             },
             $context
         );

--- a/src/MessageBus/Processor/ValidationMessageProcessor.php
+++ b/src/MessageBus/Processor/ValidationMessageProcessor.php
@@ -15,7 +15,6 @@ namespace Desperado\ServiceBus\MessageBus\Processor;
 
 use function Amp\call;
 use Amp\Promise;
-use Amp\Success;
 use Desperado\ServiceBus\Application\KernelContext;
 use Desperado\ServiceBus\Common\Contract\Messages\Message;
 use Desperado\ServiceBus\MessageBus\Contracts\MessageValidationFailed;
@@ -81,7 +80,7 @@ final class ValidationMessageProcessor implements Processor
                         self::createFailedEvent($message, $context, $violations)
                     );
 
-                    return yield new Success();
+                    return null;
                 }
 
                 return yield $processor($message, $context);

--- a/src/Sagas/Configuration/SagaEventListenerProcessor.php
+++ b/src/Sagas/Configuration/SagaEventListenerProcessor.php
@@ -15,7 +15,6 @@ namespace Desperado\ServiceBus\Sagas\Configuration;
 
 use function Amp\call;
 use Amp\Promise;
-use Amp\Success;
 use Desperado\ServiceBus\Common\Contract\Messages\Event;
 use Desperado\ServiceBus\Common\ExecutionContext\MessageDeliveryContext;
 use function Desperado\ServiceBus\Common\invokeReflectionMethod;
@@ -76,7 +75,7 @@ final class SagaEventListenerProcessor
      * @param Event                  $event
      * @param MessageDeliveryContext $context
      *
-     * @return Promise
+     * @return Promise<bool>
      */
     public function execute(Event $event, MessageDeliveryContext $context): Promise
     {
@@ -101,7 +100,7 @@ final class SagaEventListenerProcessor
 
                     yield $sagaProvider->save($saga, $context);
 
-                    return yield new Success();
+                    return true;
                 }
 
                 $logger->info('Saga with identifier "{sagaId}:{sagaClass}" not found', [
@@ -110,7 +109,7 @@ final class SagaEventListenerProcessor
                     ]
                 );
 
-                return yield new Success();
+                return true;
             },
             $event,
             $context

--- a/src/SchedulerProvider.php
+++ b/src/SchedulerProvider.php
@@ -15,7 +15,6 @@ namespace Desperado\ServiceBus;
 
 use function Amp\call;
 use Amp\Promise;
-use Amp\Success;
 use Desperado\ServiceBus\Common\Contract\Messages\Command;
 use function Desperado\ServiceBus\Common\datetimeInstantiator;
 use Desperado\ServiceBus\Common\ExecutionContext\LoggingInContext;
@@ -81,7 +80,7 @@ final class SchedulerProvider
                 {
                     yield $store->add(
                         $operation,
-                        static function(ScheduledOperation $operation, ?NextScheduledOperation $nextOperation) use ($context): \Generator
+                        static function(ScheduledOperation $operation, ?NextScheduledOperation $nextOperation) use ($context)
                         {
                             yield $context->delivery(
                                 OperationScheduled::create(
@@ -251,8 +250,6 @@ final class SchedulerProvider
                             ]
                         );
                     }
-
-                    return yield new Success();
                 }
                 catch(\Throwable $throwable)
                 {

--- a/src/Storage/SQL/AmpPostgreSQL/AmpPostgreSQLResultSet.php
+++ b/src/Storage/SQL/AmpPostgreSQL/AmpPostgreSQLResultSet.php
@@ -43,6 +43,11 @@ class AmpPostgreSQLResultSet implements ResultSet
         $this->originalResultSet = $originalResultSet;
     }
 
+    public function __destruct()
+    {
+        unset($this->originalResultSet);
+    }
+
     /**
      * @inheritdoc
      */

--- a/src/Storage/SQL/AmpPostgreSQL/AmpPostgreSQLTransactionAdapter.php
+++ b/src/Storage/SQL/AmpPostgreSQL/AmpPostgreSQLTransactionAdapter.php
@@ -16,7 +16,6 @@ namespace Desperado\ServiceBus\Storage\SQL\AmpPostgreSQL;
 use Amp\Postgres\Transaction as AmpTransaction;
 use function Amp\call;
 use Amp\Promise;
-use Amp\Success;
 use Desperado\ServiceBus\Storage\TransactionAdapter;
 
 /**
@@ -37,11 +36,6 @@ final class AmpPostgreSQLTransactionAdapter implements TransactionAdapter
     public function __construct(AmpTransaction $transaction)
     {
         $this->transaction = $transaction;
-    }
-
-    public function __destruct()
-    {
-        $this->transaction->close();
     }
 
     /**
@@ -65,9 +59,7 @@ final class AmpPostgreSQLTransactionAdapter implements TransactionAdapter
 
                     unset($statement);
 
-                    return yield new Success(
-                        new AmpPostgreSQLResultSet($result)
-                    );
+                    return new AmpPostgreSQLResultSet($result);
                 }
                     // @codeCoverageIgnoreStart
                 catch(\Throwable $throwable)

--- a/src/Storage/SQL/DoctrineDBAL/DoctrineDBALTransactionAdapter.php
+++ b/src/Storage/SQL/DoctrineDBAL/DoctrineDBALTransactionAdapter.php
@@ -74,13 +74,11 @@ final class DoctrineDBALTransactionAdapter implements TransactionAdapter
         $connection = $this->connection;
 
         return call(
-            static function() use ($connection): \Generator
+            static function() use ($connection): void
             {
                 try
                 {
                     $connection->commit();
-
-                    return yield new Success();
                 }
                     // @codeCoverageIgnoreStart
                 catch(\Throwable $throwable)
@@ -100,13 +98,11 @@ final class DoctrineDBALTransactionAdapter implements TransactionAdapter
         $connection = $this->connection;
 
         return call(
-            static function() use ($connection): \Generator
+            static function() use ($connection): void
             {
                 try
                 {
                     $connection->rollBack();
-
-                    return yield new Success();
                 }
                     // @codeCoverageIgnoreStart
                 catch(\Throwable $throwable)

--- a/src/Storage/functions.php
+++ b/src/Storage/functions.php
@@ -15,7 +15,6 @@ namespace Desperado\ServiceBus\Storage;
 
 use function Amp\call;
 use Amp\Promise;
-use Amp\Success;
 use Desperado\ServiceBus\Storage\Exceptions\OneResultExpected;
 
 /**
@@ -40,7 +39,7 @@ function fetchAll(ResultSet $iterator): Promise
                 $array[] = $iterator->getCurrent();
             }
 
-            return yield new Success($array);
+            return $array;
         },
         $iterator
     );
@@ -69,7 +68,7 @@ function fetchOne(ResultSet $iterator): Promise
             {
                 $endElement = \end($collection);
 
-                return yield new Success(false !== $endElement ? $endElement : null);
+                return false !== $endElement ? $endElement : null;
             }
 
             throw new OneResultExpected(

--- a/src/Transport/Amqp/AmqpQoSConfiguration.php
+++ b/src/Transport/Amqp/AmqpQoSConfiguration.php
@@ -19,7 +19,7 @@ namespace Desperado\ServiceBus\Transport\Amqp;
 final class AmqpQoSConfiguration
 {
     private const DEFAULT_QOS_PRE_FETCH_SIZE  = 0;
-    private const DEFAULT_QOS_PRE_FETCH_COUNT = 5;
+    private const DEFAULT_QOS_PRE_FETCH_COUNT = 100;
     private const DEFAULT_QOS_GLOBAL          = false;
 
     /**

--- a/src/Transport/Consumer.php
+++ b/src/Transport/Consumer.php
@@ -21,7 +21,7 @@ interface Consumer
     /**
      * Waiting for new messages from the broker
      *
-     * @param callable $messageProcessor static function (IncomingEnvelope $incomingEnvelope): void {}
+     * @param callable $messageProcessor static function (IncomingEnvelope $incomingEnvelope, TransportContext $context): void {}
      *
      * @return void
      */

--- a/src/Transport/IncomingEnvelope.php
+++ b/src/Transport/IncomingEnvelope.php
@@ -21,13 +21,6 @@ use Desperado\ServiceBus\Common\Contract\Messages\Message;
 final class IncomingEnvelope
 {
     /**
-     * The identifier of the received message (generated at the time of receipt from the broker)
-     *
-     * @var string
-     */
-    private $operationId;
-
-    /**
      * Serialized message (received)
      *
      * @var string
@@ -62,23 +55,12 @@ final class IncomingEnvelope
      * @param Message $decoded
      * @param array   $headers
      */
-    public function __construct(string $operationId, string $plain, array $normalized, Message $decoded, array $headers = [])
+    public function __construct(string $plain, array $normalized, Message $decoded, array $headers = [])
     {
-        $this->operationId = $operationId;
         $this->plain       = $plain;
         $this->normalized  = $normalized;
         $this->decoded     = $decoded;
         $this->headers     = $headers;
-    }
-
-    /**
-     * Receive identifier of the message (generated at the time of receipt from the broker)
-     *
-     * @return string
-     */
-    public function operationId(): string
-    {
-        return $this->operationId;
     }
 
     /**

--- a/src/Transport/TransportContext.php
+++ b/src/Transport/TransportContext.php
@@ -28,27 +28,35 @@ final class TransportContext
     private $id;
 
     /**
+     * Consumer ID
+     *
+     * @var string
+     */
+    private $consumerId;
+
+    /**
      * @var int
      */
     private $receivedAt;
 
     /**
-     * @param array $headers
+     * @param string $consumerId
      *
      * @return self
      */
-    public static function messageReceived(): self
+    public static function messageReceived(string $consumerId): self
     {
-        return new self();
+        return new self($consumerId);
     }
 
     /**
-     * Close constructor
+     * @param string $consumerId
      */
-    private function __construct()
+    private function __construct(string $consumerId)
     {
         $this->id         = uuid();
         $this->receivedAt = \microtime(true) * 10000;
+        $this->consumerId = $consumerId;
     }
 
     /**
@@ -65,5 +73,13 @@ final class TransportContext
     public function receivedAt(): int
     {
         return $this->receivedAt;
+    }
+
+    /**
+     * @return string
+     */
+    public function consumerId(): string
+    {
+        return $this->consumerId;
     }
 }

--- a/src/Transport/TransportContext.php
+++ b/src/Transport/TransportContext.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * PHP Service Bus (publish-subscribe pattern implementation)
+ * Supports Saga pattern and Event Sourcing
+ *
+ * @author  Maksim Masiukevich <desperado@minsk-info.ru>
+ * @license MIT
+ * @license https://opensource.org/licenses/MIT
+ */
+
+declare(strict_types = 1);
+
+namespace Desperado\ServiceBus\Transport;
+
+use function Desperado\ServiceBus\Common\uuid;
+
+/**
+ *
+ */
+final class TransportContext
+{
+    /**
+     * Received message ID
+     *
+     * @var string
+     */
+    private $id;
+
+    /**
+     * @var int
+     */
+    private $receivedAt;
+
+    /**
+     * @param array $headers
+     *
+     * @return self
+     */
+    public static function messageReceived(): self
+    {
+        return new self();
+    }
+
+    /**
+     * Close constructor
+     */
+    private function __construct()
+    {
+        $this->id         = uuid();
+        $this->receivedAt = \microtime(true) * 10000;
+    }
+
+    /**
+     * @return string
+     */
+    public function id(): string
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return int
+     */
+    public function receivedAt(): int
+    {
+        return $this->receivedAt;
+    }
+}

--- a/tests/Application/Kernel/Stubs/KernelTestService.php
+++ b/tests/Application/Kernel/Stubs/KernelTestService.php
@@ -22,6 +22,7 @@ use Desperado\ServiceBus\Tests\Stubs\Messages\SecondEmptyCommand;
  */
 final class KernelTestService
 {
+
     /**
      * @CommandHandler()
      *
@@ -33,6 +34,7 @@ final class KernelTestService
      * @throws \RuntimeException
      */
     public function handleWithThrowable(
+        /** @noinspection PhpUnusedParameterInspection */
         TriggerThrowableCommand $command,
         KernelContext $context
     ): void
@@ -49,6 +51,7 @@ final class KernelTestService
      * @return \Generator
      */
     public function handleWithSuccessResponse(
+        /** @noinspection PhpUnusedParameterInspection */
         TriggerResponseEventCommand $command,
         KernelContext $context
     ): \Generator
@@ -65,6 +68,7 @@ final class KernelTestService
      * @return \Generator
      */
     public function deliveryFailed(
+        /** @noinspection PhpUnusedParameterInspection */
         TriggerFailedResponseMessageSendCommand $command,
         KernelContext $context
     ): \Generator

--- a/tests/Scheduler/SchedulerProviderTest.php
+++ b/tests/Scheduler/SchedulerProviderTest.php
@@ -388,6 +388,7 @@ final class SchedulerProviderTest extends TestCase
      */
     private function createKernelContext(): KernelContext
     {
+
         $sender = function(Message $message, array $headers, IncomingEnvelope $incomingEnvelope): void
         {
             $this->kernelContextMessages [] = $message;

--- a/tests/Scheduler/SchedulerProviderTest.php
+++ b/tests/Scheduler/SchedulerProviderTest.php
@@ -399,7 +399,7 @@ final class SchedulerProviderTest extends TestCase
             new IncomingEnvelope(
                 '', [], new FirstEmptyCommand(), []
             ),
-            TransportContext::messageReceived(),
+            TransportContext::messageReceived(uuid()),
             $sender,
             $logger
         );

--- a/tests/Scheduler/SchedulerProviderTest.php
+++ b/tests/Scheduler/SchedulerProviderTest.php
@@ -35,6 +35,7 @@ use Desperado\ServiceBus\Storage\StorageAdapterFactory;
 use Desperado\ServiceBus\Tests\Stubs\Context\TestContext;
 use Desperado\ServiceBus\Tests\Stubs\Messages\FirstEmptyCommand;
 use Desperado\ServiceBus\Transport\IncomingEnvelope;
+use Desperado\ServiceBus\Transport\TransportContext;
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
@@ -396,8 +397,9 @@ final class SchedulerProviderTest extends TestCase
 
         return new KernelContext(
             new IncomingEnvelope(
-                uuid(), '', [], new FirstEmptyCommand(), []
+                '', [], new FirstEmptyCommand(), []
             ),
+            TransportContext::messageReceived(),
             $sender,
             $logger
         );

--- a/tests/Stubs/Transport/VirtualConsumer.php
+++ b/tests/Stubs/Transport/VirtualConsumer.php
@@ -14,6 +14,7 @@ declare(strict_types = 1);
 namespace Desperado\ServiceBus\Tests\Stubs\Transport;
 
 use function Amp\asyncCall;
+use function Desperado\ServiceBus\Common\uuid;
 use Desperado\ServiceBus\Transport\Consumer;
 use Desperado\ServiceBus\Transport\IncomingEnvelope;
 use Desperado\ServiceBus\Transport\Marshal\Decoder\TransportMessageDecoder;
@@ -60,7 +61,7 @@ final class VirtualConsumer implements Consumer
                 $headers
             );
 
-            asyncCall($messageProcessor, $envelope, TransportContext::messageReceived());
+            asyncCall($messageProcessor, $envelope, TransportContext::messageReceived(uuid()));
         }
     }
 }

--- a/tests/Stubs/Transport/VirtualConsumer.php
+++ b/tests/Stubs/Transport/VirtualConsumer.php
@@ -14,12 +14,10 @@ declare(strict_types = 1);
 namespace Desperado\ServiceBus\Tests\Stubs\Transport;
 
 use function Amp\asyncCall;
-use function Amp\call;
-use Amp\Promise;
-use function Desperado\ServiceBus\Common\uuid;
 use Desperado\ServiceBus\Transport\Consumer;
 use Desperado\ServiceBus\Transport\IncomingEnvelope;
 use Desperado\ServiceBus\Transport\Marshal\Decoder\TransportMessageDecoder;
+use Desperado\ServiceBus\Transport\TransportContext;
 
 /**
  *
@@ -53,7 +51,6 @@ final class VirtualConsumer implements Consumer
             $unserialized = $this->messageDecoder->unserialize($messagePayload);
 
             $envelope = new IncomingEnvelope(
-                uuid(),
                 $messagePayload,
                 $unserialized['message'],
                 $this->messageDecoder->denormalize(
@@ -63,7 +60,7 @@ final class VirtualConsumer implements Consumer
                 $headers
             );
 
-            asyncCall($messageProcessor, $envelope);
+            asyncCall($messageProcessor, $envelope, TransportContext::messageReceived());
         }
     }
 }

--- a/tests/Stubs/Transport/VirtualOutboundEnvelope.php
+++ b/tests/Stubs/Transport/VirtualOutboundEnvelope.php
@@ -28,7 +28,7 @@ final class VirtualOutboundEnvelope implements OutboundEnvelope
     /**
      * @var array
      */
-    private $headers = [];
+    private $headers;
 
     /**
      * @param string $body
@@ -36,7 +36,7 @@ final class VirtualOutboundEnvelope implements OutboundEnvelope
      */
     public function __construct(string $body, array $headers)
     {
-        $this->body = $body;
+        $this->body    = $body;
         $this->headers = $headers;
     }
 
@@ -162,17 +162,17 @@ final class VirtualOutboundEnvelope implements OutboundEnvelope
 
     public function clientId(): ?string
     {
-
+        return null;
     }
 
     public function appId(): ?string
     {
-
+        return null;
     }
 
     public function expirationTime(): ?int
     {
-
+        return null;
     }
 
     public function priority(): int

--- a/tests/Transport/Amqp/Bunny/AmqpBunnyConsumerTest.php
+++ b/tests/Transport/Amqp/Bunny/AmqpBunnyConsumerTest.php
@@ -25,6 +25,7 @@ use Desperado\ServiceBus\Transport\Amqp\AmqpQueue;
 use Desperado\ServiceBus\Transport\Amqp\Bunny\AmqpBunny;
 use Desperado\ServiceBus\Transport\IncomingEnvelope;
 use Desperado\ServiceBus\Transport\QueueBind;
+use Desperado\ServiceBus\Transport\TransportContext;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
 
@@ -109,12 +110,12 @@ final class AmqpBunnyConsumerTest extends TestCase
         $this->transport
             ->createConsumer(AmqpQueue::default('qwerty.message'))
             ->listen(
-                function(IncomingEnvelope $incomingEnvelope)
+                function(IncomingEnvelope $incomingEnvelope, TransportContext $transportContext)
                 {
                     try
                     {
-                        static::assertNotEmpty($incomingEnvelope->operationId());
-                        static::assertTrue(Uuid::isValid($incomingEnvelope->operationId()));
+                        static::assertNotEmpty($transportContext->id());
+                        static::assertTrue(Uuid::isValid($transportContext->id()));
 
                         static::assertNotEmpty($incomingEnvelope->headers());
                         static::assertCount(3, $incomingEnvelope->headers());

--- a/tests/Transport/Marshal/TransportMarshalTest.php
+++ b/tests/Transport/Marshal/TransportMarshalTest.php
@@ -16,7 +16,6 @@ namespace Desperado\ServiceBus\Tests\Transport\Marshal;
 use Desperado\ServiceBus\Tests\Stubs\Messages\CommandWithPayload;
 use Desperado\ServiceBus\Transport\Marshal\Decoder\JsonMessageDecoder;
 use Desperado\ServiceBus\Transport\Marshal\Encoder\JsonMessageEncoder;
-use Desperado\ServiceBus\Transport\Marshal\MessageDTO;
 use PHPUnit\Framework\TestCase;
 
 /**


### PR DESCRIPTION
AMQP Qos options support added to Amqp client configuration (The default number of preload messages is 100)
Limited number of tasks running simultaneously. Now, no more than 50 (previously there was no limit)
Fixed a memory leak in the transport level
Optimized RAM usage